### PR TITLE
Update rand crate to latest version (0.8). Fix for API change (gen_range).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-interface",   "command-line-utilities",   "developme
 
 [dependencies]
 clap = "2.33.0"
-rand = "0.7.2"
+rand = "0.8"
 regex = "1.5.5"
 chrono = "0.4.9"
 num-traits = "0.2"

--- a/src/faker/each_locale/japan.rs
+++ b/src/faker/each_locale/japan.rs
@@ -1423,8 +1423,8 @@ impl Data for JapanData {
     }
 
     fn gen_zip_code<R: Rng>(rng: &mut R, hyphen: bool) -> String {
-        let a: u16 = gen_range(rng, 0, 999);
-        let b: u16 = gen_range(rng, 0, 9999);
+        let a: u16 = gen_range(rng, 0..=999);
+        let b: u16 = gen_range(rng, 0..=9999);
         return if hyphen {
             format!("{:>03}-{:>04}", a, b)
         } else {
@@ -1433,9 +1433,9 @@ impl Data for JapanData {
     }
 
     fn gen_domestic_phone_number<R: Rng>(rng: &mut R, hyphen: bool) -> String {
-        let a: u8 = gen_range(rng, 0, 9);
-        let b: u16 = gen_range(rng, 0, 999);
-        let c: u16 = gen_range(rng, 0, 9999);
+        let a: u8 = gen_range(rng, 0..=9);
+        let b: u16 = gen_range(rng, 0..=999);
+        let c: u16 = gen_range(rng, 0..=9999);
         return if hyphen {
             format!("{:>02}-{:>03}-{:>04}", a, b, c)
         } else {

--- a/src/faker/each_locale/mod.rs
+++ b/src/faker/each_locale/mod.rs
@@ -150,7 +150,7 @@ trait Rand: Data {
                 return format!("{}", rng.gen::<i16>());
             }
             FakeOption::IntegerRange(minimum, maximum) => {
-                return format!("{}", gen_range(rng, *minimum, *maximum));
+                return format!("{}", gen_range(rng, *minimum..=*maximum));
             }
             FakeOption::Float => {
                 let i: i16 = rng.gen::<i16>();
@@ -272,35 +272,35 @@ trait Rand: Data {
 
             // DateTime
             FakeOption::Time(format) => {
-                let hour: u32 = gen_range(rng, 0, 23);
-                let minute: u32 = gen_range(rng, 0, 59);
-                let second: u32 = gen_range(rng, 0, 59);
+                let hour: u32 = gen_range(rng, 0..=23);
+                let minute: u32 = gen_range(rng, 0..=59);
+                let second: u32 = gen_range(rng, 0..=59);
                 let time: NaiveTime = NaiveTime::from_hms(hour, minute, second);
                 return time.format(&format).to_string();
             }
             FakeOption::Date(format) => {
                 let now_year: i32 = Local::today().year();
-                let year: i32 = gen_range(rng, now_year - 100, now_year);
-                let month: u32 = gen_range(rng, 1, 12);
-                let day: u32 = gen_range(rng, 1, 31);
+                let year: i32 = gen_range(rng, now_year - 100..=now_year);
+                let month: u32 = gen_range(rng, 1..=12);
+                let day: u32 = gen_range(rng, 1..=31);
                 let mut date: Option<NaiveDate> = NaiveDate::from_ymd_opt(year, month, day);
                 while date.is_none() {
-                    date = NaiveDate::from_ymd_opt(year, month, gen_range(rng, 1, 31));
+                    date = NaiveDate::from_ymd_opt(year, month, gen_range(rng, 1..=31));
                 }
                 return date.unwrap().format(&format).to_string();
             }
             FakeOption::DateTime(format) => {
                 let now_year: i32 = Local::today().year();
-                let year: i32 = gen_range(rng, now_year - 100, now_year);
-                let month: u32 = gen_range(rng, 1, 12);
-                let day: u32 = gen_range(rng, 1, 31);
+                let year: i32 = gen_range(rng, now_year - 100..=now_year);
+                let month: u32 = gen_range(rng, 1..=12);
+                let day: u32 = gen_range(rng, 1..=31);
                 let mut date: Option<NaiveDate> = NaiveDate::from_ymd_opt(year, month, day);
                 while date.is_none() {
-                    date = NaiveDate::from_ymd_opt(year, month, gen_range(rng, 1, 31));
+                    date = NaiveDate::from_ymd_opt(year, month, gen_range(rng, 1..=31));
                 }
-                let hour: u32 = gen_range(rng, 0, 23);
-                let minute: u32 = gen_range(rng, 0, 59);
-                let second: u32 = gen_range(rng, 0, 59);
+                let hour: u32 = gen_range(rng, 0..=23);
+                let minute: u32 = gen_range(rng, 0..=59);
+                let second: u32 = gen_range(rng, 0..=59);
                 let time: NaiveTime = NaiveTime::from_hms(hour, minute, second);
                 let date_time: NaiveDateTime = NaiveDateTime::new(date.unwrap(), time);
                 return date_time.format(&format).to_string();

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,5 +1,4 @@
-use num_traits::Num;
-use rand::distributions::uniform::SampleUniform;
+use rand::distributions::uniform::{SampleUniform, SampleRange};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::fmt::Display;
@@ -28,12 +27,12 @@ pub fn select<'a, R: Rng, I: ?Sized>(rng: &'a mut R, data: &'a [&I]) -> &'a I {
 }
 
 /// minimum <= n <= maximum
-pub fn gen_range<R: Rng, T: SampleUniform + Sized + Num>(rng: &mut R, minimum: T, maximum: T) -> T {
-    rng.gen_range::<T, T, T>(minimum, maximum + T::one())
+pub fn gen_range<R: Rng, T: SampleUniform, SR: SampleRange<T>>(rng: &mut R, range: SR) -> T {
+    rng.gen_range::<T, SR>(range)
 }
 
 pub fn gen_fraction_part<R: Rng>(rng: &mut R) -> f64 {
-    gen_range(rng, 0 as f64, 0 as f64)
+    gen_range(rng, 0 as f64..=0 as f64)
 }
 
 pub fn select_many<'a, R: Rng, I: ?Sized>(
@@ -42,7 +41,7 @@ pub fn select_many<'a, R: Rng, I: ?Sized>(
     minimum: usize,
     maximum: usize,
 ) -> Vec<&'a I> {
-    let size: usize = gen_range(rng, minimum, maximum);
+    let size: usize = gen_range(rng, minimum..=maximum);
     return data.choose_multiple(rng, size).map(|i| *i).collect();
 }
 
@@ -52,7 +51,7 @@ const PASSWORD_CHAR: &'static str =
     "0123456789ABCDEFGHIJKLMNOPWRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*()+-={}[]:;<>,./?_~|";
 
 fn gen_chars<R: Rng>(base: &str, rng: &mut R, minimum: usize, maximum: usize) -> String {
-    let size: usize = gen_range(rng, minimum, maximum);
+    let size: usize = gen_range(rng, minimum..=maximum);
     return String::from_utf8(
         base.as_bytes()
             .choose_multiple(rng, size)


### PR DESCRIPTION
Please accept this patch updating "rand" crate to latest version.

In version 0.8 rng.gen_range API changed to (min,max) to a (range).

Having rand crate up to date is important because Rng trait does not well support having different versions of the rand crates in an application. This leads to unsolvable conflicts.